### PR TITLE
Change terraform-module pipeline to use taskfile definitions

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,5 @@
 *         @saic-oss/core
+
+# Don't change me! Compliance team is the owner of these files
+/.github/         @saic-oss/compliance
+/Taskfile.yaml    @saic-oss/compliance

--- a/pipelines/terraform-module.yaml
+++ b/pipelines/terraform-module.yaml
@@ -26,4 +26,5 @@ steps:
     environment:
       - "PRE_COMMIT_HOME=/codefresh/volume/pre-commit-cache"
     commands:
+      - asdf install
       - task validatePreCommitHooks

--- a/pipelines/terraform-module.yaml
+++ b/pipelines/terraform-module.yaml
@@ -20,12 +20,10 @@ steps:
   validate:
     title: "Validating pre-commit hooks"
     type: "freestyle"
-    image: "dadsgarage/dadsgarage:0.3.3"
+    image: "dadsgarage/dadsgarage:0.3.4"
     working_directory: "${{clone}}"
     stage: "validate"
     environment:
       - "PRE_COMMIT_HOME=/codefresh/volume/pre-commit-cache"
     commands:
-      - asdf install
-      - pre-commit install
-      - pre-commit run -a
+      - task validatePreCommitHooks


### PR DESCRIPTION
## what
* Change terraform-module pipeline to use taskfile definitions
* Change CODEOWNERS to match compliance changes in template repo

## why
* Provide some level of customizability by using the taskfile rather than hand-jammed steps, while still enforcing compliance by making @saic-oss/compliance the CODEOWNER of the taskfile

## references
n/a
