### PR TITLE
Fix codeowners file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,7 @@
-*         @saic-oss/core
+*                           @saic-oss/compliance
 
 # Don't change me! Compliance team is the owner of these files
-/.github/         @saic-oss/compliance
-/Taskfile.yaml    @saic-oss/compliance
+/.github/                   @saic-oss/compliance
+/Taskfile.yml               @saic-oss/compliance
+/.pre-commit-config.yaml    @saic-oss/compliance
+/.remarkrc                  @saic-oss/compliance


### PR DESCRIPTION
## what/why
- Change primary owner to @saic-oss/compliance
    - These are the compliant pipelines, so the compliance team should own them
- Fix typos
- Add missing files to codeowners file

## references
N/A
