### PR TITLE
Bump Anvil version to 0.5.6

### DIFF
--- a/pipelines/deliver.yaml
+++ b/pipelines/deliver.yaml
@@ -1,7 +1,7 @@
 version: "1.0"
 
 indicators:
-  - image: &runner saicoss/anvil:0.5.4
+  - image: &runner saicoss/anvil:0.5.6
 
 stages:
   - "clone"

--- a/pipelines/full-ci.yaml
+++ b/pipelines/full-ci.yaml
@@ -1,7 +1,7 @@
 version: "1.0"
 
 indicators:
-  - image: &runner saicoss/anvil:0.5.4
+  - image: &runner saicoss/anvil:0.5.6
 
 stages:
   - "clone"


### PR DESCRIPTION
## what/why

- Bump Anvil version to 0.5.6, which is the latest version